### PR TITLE
feat: Notionボタンからの強制リビルドトリガーを追加

### DIFF
--- a/.github/workflows/deploy_to_s3.yaml
+++ b/.github/workflows/deploy_to_s3.yaml
@@ -4,20 +4,44 @@ on:
   push:
     tags:
       - v*
+  # Notionボタン等の外部トリガーからのリビルド用(最新のv*タグをビルドする)
+  repository_dispatch:
+    types: [rebuild-website]
 
 permissions:
   contents: read
   pages: write
   id-token: write
 
+concurrency:
+  group: deploy-website
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Resolve ref to build
+        id: resolve
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "repository_dispatch" ]; then
+            # 外部トリガー時はデフォルトブランチではなく最新のリリースタグをビルドする
+            ref=$(git ls-remote --tags "https://github.com/${GITHUB_REPOSITORY}.git" 'refs/tags/v*' \
+              | awk '{print $2}' | grep -v '\^{}$' | sed 's|^refs/tags/||' | sort -V | tail -n 1)
+            if [ -z "${ref}" ]; then
+              echo "No v* tag found" >&2
+              exit 1
+            fi
+          else
+            ref="${GITHUB_REF_NAME}"
+          fi
+          echo "Building ref: ${ref}"
+          echo "ref=${ref}" >> "${GITHUB_OUTPUT}"
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ steps.resolve.outputs.ref }}
           persist-credentials: false
       - uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:

--- a/tools/notion-rebuild-relay/README.md
+++ b/tools/notion-rebuild-relay/README.md
@@ -1,0 +1,85 @@
+# Notion → GitHub Actions リビルド中継 (GAS)
+
+Notion DBのボタンアクションからwebsiteの強制リビルドをトリガーするための中継です。
+
+## 構成
+
+```
+Notionボタン → GAS Web App → GitHub repository_dispatch → deploy_to_s3.yaml
+                (この中継)      (event_type: rebuild-website)   最新のv*タグをビルドしてデプロイ
+```
+
+中継が必要な理由: Notionのwebhookアクションはリクエストボディをカスタマイズできず、
+GitHubの`repository_dispatch` APIが必須とする`{"event_type": "..."}`形式のボディを
+送れないため、GASでボディを組み立て直して転送します。
+
+リビルド時は**最新の`v*`タグ**がビルドされます(mainのHEADではない)。コードの変更は
+従来通りreleasebotのタグリリースで反映し、このボタンはNotionコンテンツの再取得・
+再デプロイ専用です。
+
+## セットアップ手順
+
+### 1. GitHubトークンの発行
+
+Fine-grained personal access tokenを発行する:
+
+- 対象リポジトリ: `cloudnativedaysjp/website` のみ
+- 権限: **Contents: Read and write**(repository_dispatchの発行に必要)
+- 有効期限: 運用に合わせて設定(失効時はGAS側の差し替えのみで済む)
+
+組織設定でfine-grained PATが許可されていない場合はclassic PAT(`repo`スコープ)を使用。
+それも不可の場合は既存GitHub App(APP_ID / PRIVATE_KEY)のinstallation token方式への
+切り替えを検討する。
+
+### 2. GAS Web Appのデプロイ
+
+1. [script.google.com](https://script.google.com) で新規プロジェクトを作成し、`main.gs` の内容を貼り付ける
+2. プロジェクト設定 → スクリプト プロパティに以下を設定:
+   - `GITHUB_TOKEN`: 手順1で発行したトークン
+   - `SHARED_TOKEN`: 呼び出し認証用のランダム文字列(例: `openssl rand -hex 24` で生成)
+3. デプロイ → 新しいデプロイ → 種類「ウェブアプリ」:
+   - 実行ユーザー: **自分**
+   - アクセスできるユーザー: **全員**(認証は`SHARED_TOKEN`で行う)
+4. 発行されたWeb AppのURL(`https://script.google.com/macros/s/.../exec`)を控える
+
+> **注意**: `main.gs` を修正した場合は「デプロイを管理」から**新しいバージョン**として
+> 再デプロイしないと反映されない。
+
+### 3. Notionボタンの設定
+
+ブログ記事DBのボタンプロパティ(またはオートメーション)にwebhookアクションを追加:
+
+- URL: `https://script.google.com/macros/s/.../exec?token=<SHARED_TOKEN>`
+- メソッド: POST(ボディ・ヘッダーの追加設定は不要)
+
+## 動作確認
+
+```bash
+# 中継経由でトリガー(Actionsの「Deploy Website to S3」が起動すればOK)
+curl -X POST "https://script.google.com/macros/s/.../exec?token=<SHARED_TOKEN>" -L
+
+# 誤ったトークンでは {"ok":false,...} が返り、Actionsが起動しないことを確認
+curl -X POST "https://script.google.com/macros/s/.../exec?token=wrong" -L
+
+# 中継を挟まず直接GitHub APIを叩く場合(切り分け用)
+curl -X POST "https://api.github.com/repos/cloudnativedaysjp/website/dispatches" \
+  -H "Authorization: Bearer <GITHUB_TOKEN>" \
+  -H "Accept: application/vnd.github+json" \
+  -d '{"event_type": "rebuild-website"}'
+```
+
+起動したワークフローのログ(Resolve ref to buildステップ)で、最新の`v*`タグが
+checkoutされていることを確認する。
+
+## 既知の挙動・注意点
+
+- **GAS Web AppはPOSTに302リダイレクトで応答する仕様。** 処理(GitHubへの転送)は
+  最初のPOSTで実行済みのため、呼び出し元がリダイレクトを追わなくてもリビルドは走る。
+  Notion側でボタンがエラー表示になる場合があるが実害はない。
+- `repository_dispatch`は**mainブランチ上のワークフロー定義**で発火する。ワークフローの
+  変更はmainに反映されるまでボタン起動に効かない。
+- ボタン連打しても`concurrency: deploy-website`によりデプロイは直列化される
+  (実行中のデプロイはキャンセルされない)。
+- `SHARED_TOKEN`入りのURLはNotionのボタン設定を編集できる人全員に見える。漏洩が
+  疑われる場合はスクリプト プロパティの`SHARED_TOKEN`とNotion側URLを更新する
+  (できることはリビルドの起動のみで、コードやデータの変更はできない)。

--- a/tools/notion-rebuild-relay/main.gs
+++ b/tools/notion-rebuild-relay/main.gs
@@ -1,0 +1,38 @@
+// Notionのwebhookアクション(ボディ形式が固定)とGitHubのrepository_dispatch API
+// (event_typeボディが必須)の橋渡しをするGAS Web App。
+// デプロイ手順・設定値は同ディレクトリのREADME.mdを参照。
+
+const GITHUB_REPO = 'cloudnativedaysjp/website';
+const EVENT_TYPE = 'rebuild-website';
+
+function doPost(e) {
+  const props = PropertiesService.getScriptProperties();
+
+  // GASはHTTPヘッダーを参照できないため、認証はURLクエリ(?token=...)で行う
+  const expected = props.getProperty('SHARED_TOKEN');
+  const actual = e && e.parameter ? e.parameter.token : null;
+  if (!expected || actual !== expected) {
+    return jsonResponse_({ ok: false, error: 'invalid token' });
+  }
+
+  const res = UrlFetchApp.fetch(`https://api.github.com/repos/${GITHUB_REPO}/dispatches`, {
+    method: 'post',
+    contentType: 'application/json',
+    headers: {
+      Authorization: 'Bearer ' + props.getProperty('GITHUB_TOKEN'),
+      Accept: 'application/vnd.github+json',
+    },
+    payload: JSON.stringify({ event_type: EVENT_TYPE }),
+    muteHttpExceptions: true,
+  });
+
+  // repository_dispatch成功時、GitHubは204 No Contentを返す
+  const status = res.getResponseCode();
+  return jsonResponse_({ ok: status === 204, status: status });
+}
+
+function jsonResponse_(obj) {
+  return ContentService.createTextOutput(JSON.stringify(obj)).setMimeType(
+    ContentService.MimeType.JSON
+  );
+}


### PR DESCRIPTION
## 概要

Notion DBのボタンアクションからwebsiteの強制リビルドをトリガーできるようにします。ブログ記事の追加・更新をコードのリリースなしで本番へ反映するための仕組みです。

構成: Notionボタン → GAS Web App(中継) → GitHub `repository_dispatch` → `deploy_to_s3.yaml`

## 変更内容

- `deploy_to_s3.yaml` に `repository_dispatch: types: [rebuild-website]` トリガーを追加(既存のタグpushトリガーは維持)
- 外部トリガー時は**最新の`v*`タグ**を解決してビルド(mainのHEADではなく)。releasebotによる「本番 = 最新リリースタグ」の運用を維持し、コンテンツ更新とコード更新の経路を分離
- `concurrency` でデプロイの同時実行を直列化(タグリリースとボタンリビルドの競合防止)
- Notion→GitHub中継のGASコードとセットアップRunbookを `tools/notion-rebuild-relay/` に追加

## 補足

- 中継が必要な理由: Notionのwebhookアクションはリクエストボディをカスタマイズできず、`repository_dispatch` APIが必須とする `{"event_type": ...}` を直接送れないため
- GAS・PAT・Notionボタンの設定は済んでおり、疎通確認済み(dispatch受理204 / 不正トークン拒否)。本PRのマージによりボタンが実際にデプロイを起動するようになります
- マージ自体ではデプロイは走りません(デプロイのきっかけはタグpushかボタンのみ)

## 動作確認

- タグ解決ロジック(`git ls-remote | sort -V`)を実リポジトリに対してローカル実行し、最新タグ `v1.1.80` が取れることを確認
- resolveステップをタグpush/dispatch両パスで実行し期待通りのrefを出力することを確認
- 既存のタグpushデプロイは従来と同じref(`github.ref_name`)を使うため挙動変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)