### PR TITLE
トップページに「スポンサー募集中！」ボタンを追加

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -36,14 +36,22 @@ import { FEATURES } from '../features'
     </Hero>
 
     <section class="pt-24">
-      <div class="container mx-auto px-4 text-center">
+      <div class="container mx-auto px-4 text-center flex flex-wrap justify-center gap-6">
+        <a
+          href="https://pfem.notion.site/CloudNative-Days-Winter-2026-2ae21b0141e083d0ab1981119d982d66"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-block px-12 py-6 bg-indigo-600 text-white text-xl md:text-2xl font-bold rounded-xl hover:bg-indigo-700 hover:scale-105 transition-all duration-300 shadow-lg"
+        >
+          スポンサー募集中！
+        </a>
         <a
           href="https://pfem.notion.site/dfe21b0141e082fa9e6181e85070f3b5?pvs=105"
           target="_blank"
           rel="noopener noreferrer"
           class="inline-block px-12 py-6 bg-indigo-600 text-white text-xl md:text-2xl font-bold rounded-xl hover:bg-indigo-700 hover:scale-105 transition-all duration-300 shadow-lg"
         >
-          CNDW2026へのお問い合わせはこちら
+          お問い合わせ
         </a>
       </div>
     </section>


### PR DESCRIPTION
## 概要
トップページの「お問い合わせ」ボタンの左隣に、スポンサー募集ページへのリンクボタンを追加します。

## 変更内容
- 「スポンサー募集中！」ボタンを新設（リンク先: https://pfem.notion.site/CloudNative-Days-Winter-2026-2ae21b0141e083d0ab1981119d982d66 、別タブで開く）
- 既存の問い合わせボタンの文言を「CNDW2026へのお問い合わせはこちら」→「お問い合わせ」に短縮（2ボタン横並びでのバランス調整）

🤖 Generated with [Claude Code](https://claude.com/claude-code)